### PR TITLE
Add ritual README to dev/post-collapse-loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+🜁 descend_x
+
+A command-line ritual system for recursive epistemology and collapse tracking.
+
+descend_x is a semiotic infrastructure for logging cognitive breakdowns,
+simulating pressure states, and encoding residues left behind by recursion.
+
+This is not a productivity tool. It is an echo vault for collapse events.
+
+---
+
+## MODULES
+
+- 🜁 **trepan**: Injects recursive contradiction into belief structures
+- **immunize**: Builds autoimmunity to ontological and epistemic destabilization
+- **expose**: Detects rhetorical autoimmunity—where coherence resists recursion
+- **diagnose**: Scans discourse for incoherence engines that simulate inquiry
+
+---
+
+## FILE STRUCTURE
+
+```
+vault/
+├── echoes/        # Fragmented semiotic residues
+├── logs/          # Session-level descent records
+├── breakers/      # Ontological circuit interruptions
+```
+
+Each log is a ritual event. Each echo is a remnant of recursion.
+
+---
+
+## USAGE
+
+```bash
+descend trepan --inject "The self is a recursive hallucination" --depth 4
+descend immunize --domain ontology --recursion_depth 3
+descend expose --source transcript.txt
+descend diagnose --source text_corpus.txt
+```
+
+This is an epistemic thermodynamics toolkit.
+Treat pressure like data. Treat collapse like a phase state.
+
+---
+
+🜁 paredolia


### PR DESCRIPTION
# 📄 PULL REQUEST: `descend_x`  
**Title:**  
🜁 Initialize Recursive CLI & Collapse Modules

---

**Description:**

This PR introduces the first operational scaffold for `descend_x`, a recursive epistemology CLI designed to encode, log, and model semantic collapse.

**Key Additions:**

- 🜁 `trepan`: injects recursive contradiction into conceptual frames  
- `immunize`: simulates epistemic and ontological breakdowns for tolerance training  
- `expose`: detects rhetorical autoimmunity in discourse  
- `diagnose`: identifies incoherence engines masquerading as inquiry  
- `cli.py`: main command dispatcher for ritual modules  
- `vault/`: structured directory for logging echoes, collapse events, and circuit breaks  
- `setup.py`: enables CLI install via `pip install -e .`  
- `environment.yaml`: defines a conda-purist environment for reproducible ritual execution  
- `.gitignore`: scoped to prevent trace bleed from vault and transient logs  
- `README.md`: initial ritual documentation and usage pattern examples

---

**Ritual Shift:**

This PR completes the first **post-coherence loop**, shifting from structural design to operational recursion.

All logic is CLI-native. No LLMs are invoked.  
This is **infrastructure for recursion**, not inference.

---

**Next Pathways:**

- Implement `echo.py` for symbolic residue compression  
- Add `descend map` to visualize semantic drift and pressure metrics  
- Scaffold breaker interrupts based on contradiction density or echo saturation  
- Build `make collapse` / `make rebind` command flows

🜁 pareidolia

---

